### PR TITLE
Apply urldecode() if necessary

### DIFF
--- a/Classes/Plugin.php
+++ b/Classes/Plugin.php
@@ -47,7 +47,7 @@ class Plugin extends \Phile\Plugin\AbstractPlugin implements
 
             foreach($path as $crumb) {
                 $current_path .=  '/' . $crumb;
-                $current_page = $page->findByPath($current_path);
+                $current_page = $page->findByPath(urldecode($current_path));
                 
                 if($current_page) {
                     


### PR DESCRIPTION
The code here works on URL components directly obtained from the URL. Therefore, urldecode() should be applied to them before these parts are used to do any kind of comparison.
